### PR TITLE
ignore lookup failure from the DB

### DIFF
--- a/lib/fluent/plugin/out_geoip.rb
+++ b/lib/fluent/plugin/out_geoip.rb
@@ -46,8 +46,12 @@ class Fluent::GeoipOutput < Fluent::BufferedOutput
   def write(chunk)
     chunk.msgpack_each do |tag, time, record|
       result = @geoip.look_up(record[@geoip_lookup_key])
-      @geoip_keys_map.each do |geoip_key,record_key|
-        record.store(record_key, result[geoip_key.to_sym])
+      if result.nil?
+        $log.warn "geoip: failed to look up from the GeoIP DB.", :addr => record[@geoip_lookup_key]
+      else
+        @geoip_keys_map.each do |geoip_key,record_key|
+          record.store(record_key, result[geoip_key.to_sym])
+        end
       end
       $log.info "geoip: record:#{record}, result:#{result}"
       Fluent::Engine.emit(tag, time, record)

--- a/test/plugin/test_out_geoip.rb
+++ b/test/plugin/test_out_geoip.rb
@@ -44,4 +44,17 @@ class GeoipOutputTest < Test::Unit::TestCase
     assert_equal 'Mountain View', emits[0][2]['geoip_city']
   end
 
+  def test_emit_with_unknown_address
+    d1 = create_driver(CONFIG, 'input.access')
+    d1.run do
+      # 203.0.113.1 is a test address described in RFC5737
+      d1.emit({'host' => '203.0.113.1', 'message' => 'action foo'})
+    end
+    emits = d1.emits
+    assert_equal 1, emits.length
+    p emits[0]
+    assert_equal 'geoip.access', emits[0][0] # tag
+    assert_equal nil, emits[0][2]['geoip_city']
+  end
+
 end


### PR DESCRIPTION
Fix #1 with test case.

When failed to lookup from the DB, just emit and output log with warning level.
