### PR TITLE
enable to use nested ip in record

### DIFF
--- a/lib/fluent/plugin/out_geoip.rb
+++ b/lib/fluent/plugin/out_geoip.rb
@@ -1,6 +1,6 @@
 class Fluent::GeoipOutput < Fluent::BufferedOutput
   Fluent::Plugin.register_output('geoip', self)
-  
+
   GEOIP_KEYS = %w(city latitude longitude country_code3 country_code country_name dma_code area_code region)
   config_param :geoip_database, :string, :default => File.dirname(__FILE__) + '/../../../data/GeoLiteCity.dat'
   config_param :geoip_lookup_key, :string, :default => 'host'
@@ -13,7 +13,7 @@ class Fluent::GeoipOutput < Fluent::BufferedOutput
     require 'geoip'
     super
   end
-  
+
   def configure(conf)
     super
 
@@ -23,6 +23,9 @@ class Fluent::GeoipOutput < Fluent::BufferedOutput
       raise Fluent::ConfigError, "geoip: unsupported key #{geoip_key_name}" unless GEOIP_KEYS.include?(geoip_key_name)
       @geoip_keys_map.store(geoip_key_name, conf[key])
     end
+
+    @geoip_lookup_key = @geoip_lookup_key.split(".")
+
 
     if ( !@remove_tag_prefix && !@remove_tag_suffix && !@add_tag_prefix && !@add_tag_suffix )
       raise Fluent::ConfigError, "geoip: missing remove_tag_prefix, remove_tag_suffix, add_tag_prefix or add_tag_suffix."
@@ -34,11 +37,11 @@ class Fluent::GeoipOutput < Fluent::BufferedOutput
   def start
     super
   end
-  
+
   def format(tag, time, record)
     [tag, time, record].to_msgpack
   end
-  
+
   def shutdown
     super
   end
@@ -49,8 +52,17 @@ class Fluent::GeoipOutput < Fluent::BufferedOutput
     end
   end
 
+  def get_address(record)
+    obj = record
+    @geoip_lookup_key.each do |key|
+      return nil if not obj.has_key?(key)
+      obj = obj[key]
+    end
+    obj
+  end
+
   def add_geoip_field(record)
-    address = record[@geoip_lookup_key]
+    address = get_address(record)
     return record if address.nil?
     result = @geoip.look_up(address)
     return record if result.nil?

--- a/test/plugin/test_out_geoip.rb
+++ b/test/plugin/test_out_geoip.rb
@@ -40,6 +40,26 @@ class GeoipOutputTest < Test::Unit::TestCase
     end
     emits = d1.emits
     assert_equal 2, emits.length
+    # p emits[0]
+    assert_equal 'geoip.access', emits[0][0] # tag
+    assert_equal 'Mountain View', emits[0][2]['geoip_city']
+    # p emits[1]
+    assert_equal nil, emits[1][2]['geoip_city']
+  end
+
+  def test_emit_nested_attr
+    d1 = create_driver(%[
+      geoip_lookup_key  host.ip
+      enable_key_city   geoip_city
+      remove_tag_prefix input.
+      add_tag_prefix    geoip.
+    ], 'input.access')
+    d1.run do
+      d1.emit({'host' => {'ip' => '66.102.3.80'}, 'message' => 'valid ip'})
+      d1.emit({'message' => 'missing field'})
+    end
+    emits = d1.emits
+    assert_equal 2, emits.length
     p emits[0]
     assert_equal 'geoip.access', emits[0][0] # tag
     assert_equal 'Mountain View', emits[0][2]['geoip_city']
@@ -56,10 +76,10 @@ class GeoipOutputTest < Test::Unit::TestCase
     end
     emits = d1.emits
     assert_equal 2, emits.length
-    p emits[0]
+    # p emits[0]
     assert_equal 'geoip.access', emits[0][0] # tag
     assert_equal nil, emits[0][2]['geoip_city']
-    p emits[1]
+    # p emits[1]
     assert_equal 'geoip.access', emits[1][0] # tag
     assert_equal nil, emits[1][2]['geoip_city']
   end


### PR DESCRIPTION
I want to use nested key in record for lookup key.

configure bellow:

```
      geoip_lookup_key  host.ip
      enable_key_city   geoip_city
      remove_tag_prefix input.
      add_tag_prefix    geoip.
```

fluentd with this configuration can add geographical information to `{'host' => {'ip' => '66.102.3.80'}, 'message' => 'valid ip'}`.
