### PR TITLE
support multiple lookup keys

### DIFF
--- a/test/plugin/test_out_geoip.rb
+++ b/test/plugin/test_out_geoip.rb
@@ -28,8 +28,28 @@ class GeoipOutputTest < Test::Unit::TestCase
       remove_tag_prefix input.
       add_tag_prefix    geoip.
     ]
-    puts d.instance.inspect
     assert_equal 'geoip_city', d.instance.config['enable_key_city']
+    assert_equal ['geoip_city'], d.instance.geoip_keys_map['city']
+
+    # multiple key config
+    d = create_driver %[
+      geoip_lookup_key  from.ip, to.ip
+      enable_key_city   from_city, to_city
+      remove_tag_prefix input.
+      add_tag_prefix    geoip.
+    ]
+    assert_equal 'from_city, to_city', d.instance.config['enable_key_city']
+    assert_equal ['from_city', 'to_city'], d.instance.geoip_keys_map['city']
+
+    # multiple key config (bad configure)
+    assert_raise(Fluent::ConfigError) {
+      d = create_driver %[
+        geoip_lookup_key  from.ip, to.ip
+        enable_key_city   from_city
+        remove_tag_prefix input.
+        add_tag_prefix    geoip.
+      ]
+    }
   end
 
   def test_emit
@@ -40,10 +60,8 @@ class GeoipOutputTest < Test::Unit::TestCase
     end
     emits = d1.emits
     assert_equal 2, emits.length
-    # p emits[0]
     assert_equal 'geoip.access', emits[0][0] # tag
     assert_equal 'Mountain View', emits[0][2]['geoip_city']
-    # p emits[1]
     assert_equal nil, emits[1][2]['geoip_city']
   end
 
@@ -60,10 +78,8 @@ class GeoipOutputTest < Test::Unit::TestCase
     end
     emits = d1.emits
     assert_equal 2, emits.length
-    p emits[0]
     assert_equal 'geoip.access', emits[0][0] # tag
     assert_equal 'Mountain View', emits[0][2]['geoip_city']
-    p emits[1]
     assert_equal nil, emits[1][2]['geoip_city']
   end
 
@@ -76,12 +92,30 @@ class GeoipOutputTest < Test::Unit::TestCase
     end
     emits = d1.emits
     assert_equal 2, emits.length
-    # p emits[0]
     assert_equal 'geoip.access', emits[0][0] # tag
     assert_equal nil, emits[0][2]['geoip_city']
-    # p emits[1]
     assert_equal 'geoip.access', emits[1][0] # tag
     assert_equal nil, emits[1][2]['geoip_city']
+  end
+
+  def test_emit_multiple_key
+    d1 = create_driver(%[
+      geoip_lookup_key  from.ip, to.ip
+      enable_key_city   from_city, to_city
+      remove_tag_prefix input.
+      add_tag_prefix    geoip.
+    ], 'input.access')
+    d1.run do
+      d1.emit({'from' => {'ip' => '66.102.3.80'}, 'to' => {'ip' => '125.54.95.42'}})
+      d1.emit({'message' => 'missing field'})
+    end
+    emits = d1.emits
+    assert_equal 2, emits.length
+    assert_equal 'geoip.access', emits[0][0] # tag
+    assert_equal 'Mountain View', emits[0][2]['from_city']
+    assert_equal 'Musashino', emits[0][2]['to_city']
+    assert_equal nil, emits[1][2]['from_city']
+    assert_equal nil, emits[1][2]['to_city']
   end
 
 end


### PR DESCRIPTION
Lookup and insert geo infos (e.g. city) when the lookup keys are more than oen in record.

use like bellow:

```
      geoip_lookup_key  from.ip, to.ip
      enable_key_city   from_city, to_city
      remove_tag_prefix input.
      add_tag_prefix    geoip.
```

Check the size of lookup key and enable_key_XX and when the sizes are difference, raise Fluent::ConfigError.
