### PR TITLE
Shorten Buffering time from 60sec to 0sec

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ sudo /usr/lib64/fluent/ruby/bin/fluent-gem install fluent-plugin-geoip
   remove_tag_prefix        access.
   tag                      geoip.
 
-  # Buffering time (default: 60s)
+  # Buffering time (default: 0s)
   flush_interval           1s
 </match>
 ```

--- a/lib/fluent/plugin/out_geoip.rb
+++ b/lib/fluent/plugin/out_geoip.rb
@@ -15,6 +15,8 @@ class Fluent::GeoipOutput < Fluent::BufferedOutput
   include Fluent::Mixin::RewriteTagName
   config_param :hostname_command, :string, :default => 'hostname'
 
+  config_param :flush_interval, :time, :default => 0
+
   attr_reader :geoip_keys_map
 
   def initialize


### PR DESCRIPTION
The default of `flush_interval` is too long for this type of plugin.
- before: 60sec
- after: 0sec
