### PR TITLE
Add skip_adding_null_record option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ $ sudo td-agent-gem install fluent-plugin-geoip
   remove_tag_prefix access.
   tag               geoip.${tag}
 
+  # To avoid get stacktrace error with `[null, null]` array for elasticsearch.
+  skip_adding_null_record  true
+
   # Set log_level for fluentd-v0.10.43 or earlier (default: warn)
   log_level         info
 
@@ -110,12 +113,15 @@ It is a sample to get friendly geo point recdords for elasticsearch with Yajl (J
     # ex. "37.4192008972168,-122.05740356445312"
     location_string      ${latitude["host"]},${longitude["host"]}
     
-    # lat lon as array (it is useful for Kibana's bettermap.)
+    # GeoJSON (lat lon as array) is useful for Kibana's bettermap.
     # ex. [-122.05740356445312, 37.4192008972168]
     location_array       [${longitude["host"]},${latitude["host"]}]
   </record>
   remove_tag_prefix      access.
   tag                    geoip.${tag}
+
+  # To avoid get stacktrace error with `[null, null]` array for elasticsearch.
+  skip_adding_null_record  true
 </match>
 ```
 
@@ -132,6 +138,7 @@ On the case of using td-agent2 (v1-config), it have to quote `{ ... }` or `[ ...
   </record>
   remove_tag_prefix      access.
   tag                    geoip.${tag}
+  skip_adding_null_record  true
 </match>
 ```
 
@@ -208,6 +215,11 @@ Further more specification available at http://dev.maxmind.com/geoip/legacy/csv/
 
 Add original tag name into filtered record using SetTagKeyMixin.<br />
 Further details are written at http://docs.fluentd.org/articles/in_exec
+
+* `skip_adding_null_record` (default: false)
+
+Skip adding geoip fields when this valaues to `true`.
+On the case of getting nothing of GeoIP info (such as local IP), it will output the original record without changing anything.
 
 * `remove_tag_prefix`
 * `remove_tag_suffix`

--- a/fluent-plugin-geoip.gemspec
+++ b/fluent-plugin-geoip.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+
+  if defined?(RUBY_VERSION) && RUBY_VERSION > '2.2'
+    spec.add_development_dependency "test-unit", '~> 3'
+  end
+
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "fluent-mixin-rewrite-tag-name"
   spec.add_runtime_dependency "geoip-c"

--- a/lib/fluent/plugin/out_geoip.rb
+++ b/lib/fluent/plugin/out_geoip.rb
@@ -11,6 +11,7 @@ class Fluent::GeoipOutput < Fluent::BufferedOutput
   config_param :geoip_database, :string, :default => File.dirname(__FILE__) + '/../../../data/GeoLiteCity.dat'
   config_param :geoip_lookup_key, :string, :default => 'host'
   config_param :tag, :string, :default => nil
+  config_param :skip_adding_null_record, :bool, :default => false
 
   include Fluent::HandleTagNameMixin
   include Fluent::SetTagKeyMixin
@@ -119,6 +120,7 @@ class Fluent::GeoipOutput < Fluent::BufferedOutput
 
   def add_geoip_field(record)
     placeholder = create_placeholder(geolocate(get_address(record)))
+    return record if @skip_adding_null_record && placeholder.values.first.nil?
     @map.each do |record_key, value|
       if value.match(REGEXP_PLACEHOLDER_SINGLE)
         rewrited = placeholder[value]


### PR DESCRIPTION
Hi all,

On the case of getting nothing of GeoIP info (such as local IP),
it will output the original record without changing anything.

Original Issue: https://github.com/y-ken/fluent-plugin-geoip/issues/18