### PR TITLE
Use `emit_stream` instead of `emit`

### DIFF
--- a/lib/fluent/plugin/out_geoip.rb
+++ b/lib/fluent/plugin/out_geoip.rb
@@ -55,8 +55,12 @@ class Fluent::GeoipOutput < Fluent::BufferedOutput
   end
 
   def write(chunk)
-    chunk.msgpack_each do |tag, time, record|
-      router.emit(tag, time, @geoip.add_geoip_field(record))
+    es = Fluent::MultiEventStream.new
+    tag = ""
+    chunk.msgpack_each do |_tag, time, record|
+      tag = _tag
+      es.add(time, @geoip.add_geoip_field(record))
     end
+    router.emit_stream(tag, es)
   end
 end


### PR DESCRIPTION
This is for performance.
See https://github.com/y-ken/fluent-plugin-geoip/pull/24#discussion_r36718328