### PR TITLE
Use `Fluent::BufferedOutput` instead of `Fluent::Output`

### DIFF
--- a/lib/fluent/plugin/geoip.rb
+++ b/lib/fluent/plugin/geoip.rb
@@ -56,7 +56,7 @@ module Fluent
         raise Fluent::ConfigError, "geoip: unsupported key #{geoip_key}" unless GEOIP_KEYS.include?(geoip_key)
       end
 
-      if plugin.is_a?(Fluent::Output)
+      if plugin.is_a?(Fluent::BufferedOutput)
         @placeholder_expander = PlaceholderExpander.new
         unless have_tag_option?(plugin)
           raise Fluent::ConfigError, "geoip: required at least one option of 'tag', 'remove_tag_prefix', 'remove_tag_suffix', 'add_tag_prefix', 'add_tag_suffix'."


### PR DESCRIPTION
Because (on Fluentd v0.14):

* `Fluent::Output == Fluent::Compat::Output`
* `Fluent::BufferedOutput == Fluent::Compat::BufferedOutput`
* `Fluent::BufferedOutput` does not inherit `Fluent::Output`