### PR TITLE
Cleanup default value of geoip_database and geoip2_database

### DIFF
--- a/lib/fluent/plugin/filter_geoip.rb
+++ b/lib/fluent/plugin/filter_geoip.rb
@@ -5,8 +5,8 @@ module Fluent::Plugin
   class GeoipFilter < Fluent::Plugin::Filter
     Fluent::Plugin.register_filter('geoip', self)
 
-    config_param :geoip_database, :string, default: File.dirname(__FILE__) + '/../../../data/GeoLiteCity.dat'
-    config_param :geoip2_database, :string, default: File.dirname(__FILE__) + '/../../../data/GeoLite2-City.mmdb'
+    config_param :geoip_database, :string, default: File.expand_path('../../../data/GeoLiteCity.dat', __dir__)
+    config_param :geoip2_database, :string, default: File.expand_path('../../../data/GeoLite2-City.mmdb', __dir__)
     config_param :geoip_lookup_key, :string, default: 'host'
     config_param :skip_adding_null_record, :bool, default: false
 

--- a/lib/fluent/plugin/out_geoip.rb
+++ b/lib/fluent/plugin/out_geoip.rb
@@ -6,8 +6,8 @@ class Fluent::Plugin::GeoipOutput < Fluent::Plugin::Output
 
   helpers :event_emitter, :inject, :compat_parameters
 
-  config_param :geoip_database, :string, default: File.dirname(__FILE__) + '/../../../data/GeoLiteCity.dat'
-  config_param :geoip2_database, :string, default: File.dirname(__FILE__) + '/../../../data/GeoLite2-City.mmdb'
+  config_param :geoip_database, :string, default: File.expand_path('../../../data/GeoLiteCity.dat', __dir__)
+  config_param :geoip2_database, :string, default: File.expand_path('../../../data/GeoLite2-City.mmdb', __dir__)
   config_param :geoip_lookup_key, :string, default: 'host'
   config_param :tag, :string, default: nil
   config_param :skip_adding_null_record, :bool, default: false


### PR DESCRIPTION
In previous version, the default value is relative path that includes
some "..". In this version, the default value is absolute path such as
"/home/user/ruby/fluent-plugin-geoip/data/GeoLite2-City.mmdb".