### PR TITLE
Rename to geoip_lookup_keys from geoip_lookup_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,11 +439,17 @@ Path to GeoIP database file.
 
 Path to GeoIP2 database file.
 
-**geoip_lookup_key** (string) (optional)
+**geoip_lookup_keys** (array) (optional)
 
-* Default value: `host`.
+* Default_value: `["host"]`
 
 Specify one or more geoip lookup field which has IP address.
+
+**geoip_lookup_key** (string) (optional) (deprecated)
+
+* Default value: `nil`.
+
+Use geoip_lookup_keys instead.
 
 **skip_adding_null_record** (bool) (optional)
 
@@ -490,11 +496,17 @@ Path to GeoIP database file.
 
 Path to GeoIP2 database file.
 
-**geoip_lookup_key** (string) (optional)
+**geoip_lookup_keys** (array) (optional)
 
-* Default value: `host`.
+* Default value: `["host"]`
 
 Specify one or more geoip lookup field which has IP address.
+
+**geoip_lookup_key** (string) (optional) (deprecated)
+
+* Default value: `nil`.
+
+Use geoip_lookup_keys instead.
 
 **skip_adding_null_record** (bool) (optional)
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Note that filter version of geoip plugin does not have handling tag feature.
 
   # Specify one or more geoip lookup field which has ip address (default: host)
   # in the case of accessing nested value, delimit keys by dot like 'host.ip'.
-  geoip_lookup_key  host
+  geoip_lookup_keys host
 
   # Specify optional geoip database (using bundled GeoLiteCity databse by default)
   # geoip_database    "/path/to/your/GeoIPCity.dat"
@@ -149,7 +149,7 @@ Note that filter version of geoip plugin does not have handling tag feature.
 ```xml
 <filter access.apache>
   @type geoip
-  geoip_lookup_key  user1_host, user2_host
+  geoip_lookup_keys user1_host, user2_host
   <record>
     user1_city      ${city.names.en["user1_host"]}
     user2_city      ${city.names.en["user2_host"]}
@@ -164,7 +164,7 @@ It is a sample to get friendly geo point recdords for elasticsearch with Yajl (J
 ```
 <filter access.apache>
   @type                  geoip
-  geoip_lookup_key       host
+  geoip_lookup_keys      host
   <record>
     # lat lon as properties
     # ex. {"lat" => 37.4192008972168, "lon" => -122.05740356445312 }
@@ -189,7 +189,7 @@ On the case of using td-agent3 (v1-config), it have to quote `{ ... }` or `[ ...
 ```
 <filter access.apache>
   @type                  geoip
-  geoip_lookup_key       host
+  geoip_lookup_keys      host
   <record>
     location_properties  '{ "lat" : ${location.latitude["host"]}, "lon" : ${location.longitude["host"]} }'
     location_string      ${location.latitude["host"]},${location.longitude["host"]}
@@ -207,7 +207,7 @@ On the case of using td-agent3 (v1-config), it have to quote `{ ... }` or `[ ...
 
   # Specify one or more geoip lookup field which has ip address (default: host)
   # in the case of accessing nested value, delimit keys by dot like 'host.ip'.
-  geoip_lookup_key  host
+  geoip_lookup_keys host
 
   # Specify optional geoip database (using bundled GeoLiteCity databse by default)
   geoip_database    "/path/to/your/GeoIPCity.dat"
@@ -255,9 +255,10 @@ On the case of using td-agent3 (v1-config), it have to quote `{ ... }` or `[ ...
   @type forward
 </source>
 
+
 <filter test.geoip>
   @type    geoip
-  geoip_lookup_key  host
+  geoip_lookup_keys  host
   <record>
     city  ${city.names.en["host"]}
     lat   ${location.latitude["host"]}
@@ -305,7 +306,7 @@ $ bundle exec ruby urils/dump.rb geoip 66.102.3.80
   </store>
   <store>
     @type    geoip
-    geoip_lookup_key  host
+    geoip_lookup_keys  host
     <record>
       lat     ${location.latitude["host"]}
       lon     ${location.longitude["host"]}

--- a/lib/fluent/plugin/filter_geoip.rb
+++ b/lib/fluent/plugin/filter_geoip.rb
@@ -10,7 +10,7 @@ module Fluent::Plugin
     config_param :geoip_database, :string, default: File.expand_path('../../../data/GeoLiteCity.dat', __dir__)
     config_param :geoip2_database, :string, default: File.expand_path('../../../data/GeoLite2-City.mmdb', __dir__)
     config_param :geoip_lookup_keys, :array, value_type: :string, default: ["host"]
-    config_param :geoip_lookup_key, :string, default: 'host', obsoleted: "Use geoip_lookup_keys instead"
+    config_param :geoip_lookup_key, :string, default: nil, deprecated: "Use geoip_lookup_keys instead"
     config_param :skip_adding_null_record, :bool, default: false
 
     config_set_default :@log_level, "warn"

--- a/lib/fluent/plugin/filter_geoip.rb
+++ b/lib/fluent/plugin/filter_geoip.rb
@@ -9,7 +9,8 @@ module Fluent::Plugin
 
     config_param :geoip_database, :string, default: File.expand_path('../../../data/GeoLiteCity.dat', __dir__)
     config_param :geoip2_database, :string, default: File.expand_path('../../../data/GeoLite2-City.mmdb', __dir__)
-    config_param :geoip_lookup_key, :string, default: 'host'
+    config_param :geoip_lookup_keys, :array, value_type: :string, default: ["host"]
+    config_param :geoip_lookup_key, :string, default: 'host', obsoleted: "Use geoip_lookup_keys instead"
     config_param :skip_adding_null_record, :bool, default: false
 
     config_set_default :@log_level, "warn"

--- a/lib/fluent/plugin/geoip.rb
+++ b/lib/fluent/plugin/geoip.rb
@@ -24,8 +24,7 @@ module Fluent
 
     def initialize(plugin, conf)
       @map = {}
-      plugin.geoip_lookup_key = plugin.geoip_lookup_key.split(/\s*,\s*/)
-      @geoip_lookup_key = plugin.geoip_lookup_key
+      @geoip_lookup_keys = plugin.geoip_lookup_keys
       @skip_adding_null_record = plugin.skip_adding_null_record
       @log = plugin.log
 
@@ -112,7 +111,7 @@ module Fluent
 
     def get_address(record)
       address = {}
-      @geoip_lookup_key.each do |field|
+      @geoip_lookup_keys.each do |field|
         address[field] = record[field] || record.dig(*field.split('.'))
       end
       address

--- a/lib/fluent/plugin/geoip.rb
+++ b/lib/fluent/plugin/geoip.rb
@@ -25,6 +25,9 @@ module Fluent
     def initialize(plugin, conf)
       @map = {}
       @geoip_lookup_keys = plugin.geoip_lookup_keys
+      if plugin.geoip_lookup_key
+        @geoip_lookup_keys = plugin.geoip_lookup_key.split(/\s*,\s*/)
+      end
       @skip_adding_null_record = plugin.skip_adding_null_record
       @log = plugin.log
 

--- a/lib/fluent/plugin/out_geoip.rb
+++ b/lib/fluent/plugin/out_geoip.rb
@@ -9,7 +9,7 @@ class Fluent::Plugin::GeoipOutput < Fluent::Plugin::Output
   config_param :geoip_database, :string, default: File.expand_path('../../../data/GeoLiteCity.dat', __dir__)
   config_param :geoip2_database, :string, default: File.expand_path('../../../data/GeoLite2-City.mmdb', __dir__)
   config_param :geoip_lookup_keys, :array, value_type: :string, default: ["host"]
-  config_param :geoip_lookup_key, :string, default: 'host', obsoleted: "Use geoip_lookup_keys instead"
+  config_param :geoip_lookup_key, :string, default: nil, deprecated: "Use geoip_lookup_keys instead"
   config_param :tag, :string, default: nil
   config_param :skip_adding_null_record, :bool, default: false
 

--- a/lib/fluent/plugin/out_geoip.rb
+++ b/lib/fluent/plugin/out_geoip.rb
@@ -8,7 +8,8 @@ class Fluent::Plugin::GeoipOutput < Fluent::Plugin::Output
 
   config_param :geoip_database, :string, default: File.expand_path('../../../data/GeoLiteCity.dat', __dir__)
   config_param :geoip2_database, :string, default: File.expand_path('../../../data/GeoLite2-City.mmdb', __dir__)
-  config_param :geoip_lookup_key, :string, default: 'host'
+  config_param :geoip_lookup_keys, :array, value_type: :string, default: ["host"]
+  config_param :geoip_lookup_key, :string, default: 'host', obsoleted: "Use geoip_lookup_keys instead"
   config_param :tag, :string, default: nil
   config_param :skip_adding_null_record, :bool, default: false
 

--- a/test/plugin/test_filter_geoip.rb
+++ b/test/plugin/test_filter_geoip.rb
@@ -9,7 +9,7 @@ class GeoipFilterTest < Test::Unit::TestCase
   end
 
   CONFIG = %[
-    geoip_lookup_key  host
+    geoip_lookup_keys  host
     <record>
       geoip_city ${city.names.en['host']}
     </record>
@@ -55,7 +55,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     test "invalid json structure w/ Ruby hash like" do
       assert_raise(Fluent::ConfigParseError) {
         create_driver %[
-          geoip_lookup_key  host
+          geoip_lookup_keys host
           <record>
             invalid_json    {"foo" => 123}
           </record>
@@ -66,7 +66,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     test "invalid json structure w/ unquoted string literal" do
       assert_raise(Fluent::ConfigParseError) {
         create_driver %[
-          geoip_lookup_key  host
+          geoip_lookup_keys host
           <record>
             invalid_json    {"foo" : string, "bar" : 123}
           </record>
@@ -115,7 +115,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_with_dot_key
       config = %[
         backend_library   geoip2_c
-        geoip_lookup_key  ip.origin, ip.dest
+        geoip_lookup_keys ip.origin, ip.dest
         <record>
           origin_country  ${country.iso_code['ip.origin']}
           dest_country    ${country.iso_code['ip.dest']}
@@ -135,7 +135,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_with_unknown_address
       config = %[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city.names.en['host']}
           geopoint        [${location.longitude['host']}, ${location.latitude['host']}]
@@ -158,7 +158,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_with_skip_unknown_address
       config = %[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city.names.en['host']}
           geopoint        [${location.longitude['host']}, ${location.latitude['host']}]
@@ -184,7 +184,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive
       config = %[
         backend_library   geoip2_c
-        geoip_lookup_key  from.ip
+        geoip_lookup_keys from.ip
         <record>
           from_city       ${city.names.en['from.ip']}
           from_country    ${country.names.en['from.ip']}
@@ -251,7 +251,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive_multiple_record
       config = %[
         backend_library   geoip2_c
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys from.ip, to.ip
         <record>
           from_city       ${city.names.en['from.ip']}
           to_city         ${city.names.en['to.ip']}
@@ -290,7 +290,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def config_quoted_record
       %[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  '{ "country_code" : "${country.iso_code["host"]}", "lat": ${location.latitude["host"]}, "lon": ${location.longitude["host"]} }'
           location_string      ${location.latitude['host']},${location.longitude['host']}
@@ -351,7 +351,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_multiline_v1_config
       config = %[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  {
             "city": "${city.names.en['host']}",
@@ -382,7 +382,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_when_latitude_longitude_is_nil
       config = %[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys  host
         <record>
           latitude  ${location.latitude['host']}
           longitude ${location.longitude['host']}
@@ -410,7 +410,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_with_dot_key
       config = %[
         backend_library   geoip2_compat
-        geoip_lookup_key  ip.origin, ip.dest
+        geoip_lookup_keys ip.origin, ip.dest
         <record>
           origin_country  ${country_code['ip.origin']}
           dest_country    ${country_code['ip.dest']}
@@ -430,7 +430,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_with_unknown_address
       config = %[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
           geopoint        [${longitude['host']}, ${latitude['host']}]
@@ -453,7 +453,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_with_skip_unknown_address
       config = %[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
           geopoint        [${longitude['host']}, ${latitude['host']}]
@@ -479,7 +479,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive
       config = %[
         backend_library   geoip2_compat
-        geoip_lookup_key  from.ip
+        geoip_lookup_keys from.ip
         <record>
           from_city       ${city['from.ip']}
           from_country    ${country_name['from.ip']}
@@ -546,7 +546,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive_multiple_record
       config = %[
         backend_library   geoip2_compat
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys from.ip, to.ip
         <record>
           from_city       ${city['from.ip']}
           to_city         ${city['to.ip']}
@@ -585,7 +585,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def config_quoted_record
       %[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  '{ "country_code" : "${country_code["host"]}", "lat": ${latitude["host"]}, "lon": ${longitude["host"]} }'
           location_string      ${latitude['host']},${longitude['host']}
@@ -646,7 +646,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_multiline_v1_config
       config = %[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  {
             "city": "${city['host']}",
@@ -677,7 +677,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_when_latitude_longitude_is_nil
       config = %[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys  host
         <record>
           latitude  ${latitude['host']}
           longitude ${longitude['host']}
@@ -705,7 +705,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter
       config = %[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys  host
         <record>
           geoip_city ${city['host']}
         </record>
@@ -725,7 +725,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_with_dot_key
       config = %[
         backend_library geoip
-        geoip_lookup_key  ip.origin, ip.dest
+        geoip_lookup_keys ip.origin, ip.dest
         <record>
           origin_country  ${country_code['ip.origin']}
           dest_country    ${country_code['ip.dest']}
@@ -745,7 +745,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_nested_attr
       config = %[
         backend_library geoip
-        geoip_lookup_key  host.ip
+        geoip_lookup_keys  host.ip
         <record>
           geoip_city ${city['host.ip']}
         </record>
@@ -765,7 +765,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_with_unknown_address
       config = %[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
           geopoint        [${longitude['host']}, ${latitude['host']}]
@@ -788,7 +788,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_with_skip_unknown_address
       config = %[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
           geopoint        [${longitude['host']}, ${latitude['host']}]
@@ -814,7 +814,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_multiple_key
       config = %[
         backend_library geoip
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys  from.ip, to.ip
         <record>
           from_city ${city['from.ip']}
           to_city   ${city['to.ip']}
@@ -836,7 +836,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_multiple_key_multiple_record
       config = %[
         backend_library geoip
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys  from.ip, to.ip
         <record>
           from_city    ${city['from.ip']}
           from_country ${country_name['from.ip']}
@@ -880,7 +880,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive
       config = %[
         backend_library geoip
-        geoip_lookup_key  from.ip
+        geoip_lookup_keys from.ip
         <record>
           from_city       ${city['from.ip']}
           from_country    ${country_name['from.ip']}
@@ -947,7 +947,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive_multiple_record
       config = %[
         backend_library geoip
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys from.ip, to.ip
         <record>
           from_city       ${city['from.ip']}
           to_city         ${city['to.ip']}
@@ -986,7 +986,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def config_quoted_record
       %[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  '{ "country_code" : "${country_code["host"]}", "lat": ${latitude["host"]}, "lon": ${longitude["host"]} }'
           location_string      ${latitude['host']},${longitude['host']}
@@ -1047,7 +1047,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_multiline_v1_config
       config = %[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  {
             "city": "${city['host']}",
@@ -1078,7 +1078,7 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_when_latitude_longitude_is_nil
       config = %[
         backend_library   geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys  host
         <record>
           latitude  ${latitude['host']}
           longitude ${longitude['host']}

--- a/test/plugin/test_filter_geoip.rb
+++ b/test/plugin/test_filter_geoip.rb
@@ -52,6 +52,19 @@ class GeoipFilterTest < Test::Unit::TestCase
       }
     end
 
+    test "deprecated configuration geoip_lookup_key" do
+      conf = %[
+        geoip_lookup_key  host,ip
+        <record>
+          geoip_city ${city['host']}
+        </record>
+        tag               geoip.${tag[1]}
+      ]
+      d = create_driver(conf)
+      assert_equal(["host", "ip"],
+                   d.instance.instance_variable_get(:@geoip).instance_variable_get(:@geoip_lookup_keys))
+    end
+
     test "invalid json structure w/ Ruby hash like" do
       assert_raise(Fluent::ConfigParseError) {
         create_driver %[

--- a/test/plugin/test_out_geoip.rb
+++ b/test/plugin/test_out_geoip.rb
@@ -32,6 +32,19 @@ class GeoipOutputTest < Test::Unit::TestCase
       }
     end
 
+    test "deprecated configuration geoip_lookup_key" do
+      conf = %[
+        geoip_lookup_key  host,ip
+        <record>
+          geoip_city ${city['host']}
+        </record>
+        tag               geoip.${tag[1]}
+      ]
+      d = create_driver(conf)
+      assert_equal(["host", "ip"],
+                   d.instance.instance_variable_get(:@geoip).instance_variable_get(:@geoip_lookup_keys))
+    end
+
     test "invalid json structure w/ Ruby hash like" do
       assert_raise(Fluent::ConfigParseError) do
         create_driver %[

--- a/test/plugin/test_out_geoip.rb
+++ b/test/plugin/test_out_geoip.rb
@@ -8,7 +8,7 @@ class GeoipOutputTest < Test::Unit::TestCase
   end
 
   CONFIG = %[
-    geoip_lookup_key  host
+    geoip_lookup_keys  host
     <record>
       geoip_city ${city['host']}
     </record>
@@ -35,7 +35,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     test "invalid json structure w/ Ruby hash like" do
       assert_raise(Fluent::ConfigParseError) do
         create_driver %[
-          geoip_lookup_key  host
+          geoip_lookup_keys host
           <record>
             invalid_json    {"foo" => 123}
           </record>
@@ -47,7 +47,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     test "invalid json structure w/ unquoted string literal" do
       assert_raise(Fluent::ConfigParseError) do
         create_driver %[
-          geoip_lookup_key  host
+          geoip_lookup_keys host
           <record>
             invalid_json    {"foo" : string, "bar" : 123}
           </record>
@@ -100,7 +100,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_tag_option
       d1 = create_driver(%[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city.names.en['host']}
         </record>
@@ -120,7 +120,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_tag_parts
       d1 = create_driver(%[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city.names.en['host']}
         </record>
@@ -138,7 +138,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_with_dot_key
       d1 = create_driver(%[
         backend_library   geoip2_c
-        geoip_lookup_key  ip.origin, ip.dest
+        geoip_lookup_keys ip.origin, ip.dest
         <record>
           origin_country  ${country.iso_code['ip.origin']}
           dest_country    ${country.iso_code['ip.dest']}
@@ -158,7 +158,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_with_unknown_address
       d1 = create_driver(%[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city.names.en['host']}
           geopoint        [${location.longitude['host']}, ${location.latitude['host']}]
@@ -182,7 +182,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_with_skip_unknown_address
       d1 = create_driver(%[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city.names.en['host']}
           geopoint        [${location.longitude['host']}, ${location.latitude['host']}]
@@ -211,7 +211,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_record_directive
       d1 = create_driver(%[
         backend_library   geoip2_c
-        geoip_lookup_key  from.ip
+        geoip_lookup_keys from.ip
         <record>
           from_city       ${city.names.en['from.ip']}
           from_country    ${country.names.en['from.ip']}
@@ -276,7 +276,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_record_directive_multiple_record
       d1 = create_driver(%[
         backend_library   geoip2_c
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys from.ip, to.ip
         <record>
           from_city       ${city.names.en['from.ip']}
           to_city         ${city.names.en['to.ip']}
@@ -310,7 +310,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def config_quoted_record
       %[
       backend_library   geoip2_c
-      geoip_lookup_key  host
+      geoip_lookup_keys host
       <record>
         location_properties  '{ "country_code" : "${country.iso_code["host"]}", "lat": ${location.latitude["host"]}, "lon": ${location.longitude["host"]} }'
         location_string      ${location.latitude['host']},${location.longitude['host']}
@@ -360,7 +360,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_multiline_v1_config
       d1 = create_driver(%[
         backend_library   geoip2_c
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  {
             "city": "${city.names.en['host']}",
@@ -386,7 +386,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_tag_option
       d1 = create_driver(%[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
         </record>
@@ -406,7 +406,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_tag_parts
       d1 = create_driver(%[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
         </record>
@@ -424,7 +424,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_with_dot_key
       d1 = create_driver(%[
         backend_library   geoip2_compat
-        geoip_lookup_key  ip.origin, ip.dest
+        geoip_lookup_keys ip.origin, ip.dest
         <record>
           origin_country  ${country_code['ip.origin']}
           dest_country    ${country_code['ip.dest']}
@@ -444,7 +444,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_with_unknown_address
       d1 = create_driver(%[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
           geopoint        [${longitude['host']}, ${latitude['host']}]
@@ -468,7 +468,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_with_skip_unknown_address
       d1 = create_driver(%[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
           geopoint        [${longitude['host']}, ${latitude['host']}]
@@ -497,7 +497,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_record_directive
       d1 = create_driver(%[
         backend_library   geoip2_compat
-        geoip_lookup_key  from.ip
+        geoip_lookup_keys from.ip
         <record>
           from_city       ${city['from.ip']}
           from_country    ${country_name['from.ip']}
@@ -562,7 +562,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_record_directive_multiple_record
       d1 = create_driver(%[
         backend_library   geoip2_compat
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys from.ip, to.ip
         <record>
           from_city       ${city['from.ip']}
           to_city         ${city['to.ip']}
@@ -596,7 +596,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def config_quoted_record
       %[
       backend_library   geoip2_compat
-      geoip_lookup_key  host
+      geoip_lookup_keys host
       <record>
         location_properties  '{ "country_code" : "${country_code["host"]}", "lat": ${latitude["host"]}, "lon": ${longitude["host"]} }'
         location_string      ${latitude['host']},${longitude['host']}
@@ -646,7 +646,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_multiline_v1_config
       d1 = create_driver(%[
         backend_library   geoip2_compat
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  {
             "city": "${city['host']}",
@@ -672,7 +672,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_tag_option
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
         </record>
@@ -692,7 +692,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_tag_parts
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
         </record>
@@ -710,7 +710,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_with_dot_key
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  ip.origin, ip.dest
+        geoip_lookup_keys ip.origin, ip.dest
         <record>
           origin_country  ${country_code['ip.origin']}
           dest_country    ${country_code['ip.dest']}
@@ -730,7 +730,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_nested_attr
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  host.ip
+        geoip_lookup_keys  host.ip
         <record>
           geoip_city ${city['host.ip']}
         </record>
@@ -750,7 +750,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_with_unknown_address
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
           geopoint        [${longitude['host']}, ${latitude['host']}]
@@ -774,7 +774,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_with_skip_unknown_address
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           geoip_city      ${city['host']}
           geopoint        [${longitude['host']}, ${latitude['host']}]
@@ -803,7 +803,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_multiple_key
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys  from.ip, to.ip
         <record>
           from_city ${city['from.ip']}
           to_city   ${city['to.ip']}
@@ -826,7 +826,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_multiple_key_multiple_record
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys  from.ip, to.ip
         <record>
           from_city    ${city['from.ip']}
           from_country ${country_name['from.ip']}
@@ -862,7 +862,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_record_directive
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  from.ip
+        geoip_lookup_keys from.ip
         <record>
           from_city       ${city['from.ip']}
           from_country    ${country_name['from.ip']}
@@ -927,7 +927,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_record_directive_multiple_record
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  from.ip, to.ip
+        geoip_lookup_keys from.ip, to.ip
         <record>
           from_city       ${city['from.ip']}
           to_city         ${city['to.ip']}
@@ -961,7 +961,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def config_quoted_record
       %[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  '{ "country_code" : "${country_code["host"]}", "lat": ${latitude["host"]}, "lon": ${longitude["host"]} }'
           location_string      ${latitude['host']},${longitude['host']}
@@ -1011,7 +1011,7 @@ class GeoipOutputTest < Test::Unit::TestCase
     def test_emit_multiline_v1_config
       d1 = create_driver(%[
         backend_library geoip
-        geoip_lookup_key  host
+        geoip_lookup_keys host
         <record>
           location_properties  {
             "city": "${city['host']}",


### PR DESCRIPTION
`geoip_lookup_key` accepts multiple keys so we should use plural form
for this parameter.