### PR TITLE
Use built-in record_accessor plugin helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Note that filter version of geoip plugin does not have handling tag feature.
   @type geoip
 
   # Specify one or more geoip lookup field which has ip address (default: host)
-  # in the case of accessing nested value, delimit keys by dot like 'host.ip'.
   geoip_lookup_keys host
 
   # Specify optional geoip database (using bundled GeoLiteCity databse by default)
@@ -189,6 +188,12 @@ We can avoid this behavior changing field order in `<record>` like following:
   skip_adding_null_record true
 </filter>
 ```
+
+#### Tips: nested attributes for geoip_lookup_keys
+
+See [Record Accessor Plugin](https://docs.fluentd.org/v1.0/articles/api-plugin-helper-record_accessor#syntax)
+
+**NOTE** Since v1.3.0 does not interpret `host.ip` as nested attribute.
 
 #### Advanced config samples
 

--- a/fluent-plugin-geoip.gemspec
+++ b/fluent-plugin-geoip.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "test-unit", ">= 3.1.0"
+  spec.add_development_dependency "test-unit-rr"
   spec.add_development_dependency "geoip2_compat"
 
   spec.add_runtime_dependency "fluentd", [">= 0.14.8", "< 2"]

--- a/lib/fluent/plugin/filter_geoip.rb
+++ b/lib/fluent/plugin/filter_geoip.rb
@@ -19,12 +19,13 @@ module Fluent::Plugin
     BACKEND_LIBRARIES = [:geoip, :geoip2_compat, :geoip2_c]
 
     REGEXP_PLACEHOLDER_SINGLE = /^\$\{(?<geoip_key>-?[^\[]+)\[['"](?<record_key>-?[^'"]+)['"]\]\}$/
+    REGEXP_PLACEHOLDER_BRACKET_SINGLE = /^\$\{(?<geoip_key>[^{}\[\]]+)\[["'](?<record_key>[^{}]+)["']\]\}$/
     REGEXP_PLACEHOLDER_SCAN = /['"]?(\$\{[^\}]+?\})['"]?/
 
     GEOIP_KEYS = %w(city latitude longitude country_code3 country_code country_name dma_code area_code region)
     GEOIP2_COMPAT_KEYS = %w(city country_code country_name latitude longitude postal_code region region_name)
 
-    helpers :compat_parameters, :inject
+    helpers :compat_parameters, :inject, :record_accessor
 
     config_param :geoip_database, :string, default: File.expand_path('../../../data/GeoLiteCity.dat', __dir__)
     config_param :geoip2_database, :string, default: File.expand_path('../../../data/GeoLite2-City.mmdb', __dir__)
@@ -44,6 +45,8 @@ module Fluent::Plugin
       if @geoip_lookup_key
         @geoip_lookup_keys = @geoip_lookup_key.split(/\s*,\s*/)
       end
+
+      @geoip_lookup_accessors = @geoip_lookup_keys.map {|key| [key, record_accessor_create(key)] }.to_h
 
       if conf.keys.any? {|k| k =~ /^enable_key_/ }
         raise Fluent::ConfigError, "geoip: 'enable_key_*' config format is obsoleted. use <record></record> directive instead."
@@ -71,7 +74,8 @@ module Fluent::Plugin
 
       @placeholder_keys = @map.values.join.scan(REGEXP_PLACEHOLDER_SCAN).map{|placeholder| placeholder[0] }.uniq
       @placeholder_keys.each do |key|
-        geoip_key = key.match(REGEXP_PLACEHOLDER_SINGLE)[:geoip_key]
+        m = key.match(REGEXP_PLACEHOLDER_SINGLE) || key.match(REGEXP_PLACEHOLDER_BRACKET_SINGLE)
+        geoip_key = m[:geoip_key]
         case @backend_library
         when :geoip
           raise Fluent::ConfigError, "#{@backend_library}: unsupported key #{geoip_key}" unless GEOIP_KEYS.include?(geoip_key)
@@ -106,7 +110,7 @@ module Fluent::Plugin
       placeholder = create_placeholder(geolocate(get_address(record)))
       return record if @skip_adding_null_record && placeholder.values.first.nil?
       @map.each do |record_key, value|
-        if value.match(REGEXP_PLACEHOLDER_SINGLE)
+        if value.match(REGEXP_PLACEHOLDER_SINGLE) || value.match(REGEXP_PLACEHOLDER_BRACKET_SINGLE)
           rewrited = placeholder[value]
         elsif json?(value)
           rewrited = value.gsub(REGEXP_PLACEHOLDER_SCAN) {|match|
@@ -142,8 +146,8 @@ module Fluent::Plugin
 
     def get_address(record)
       address = {}
-      @geoip_lookup_keys.each do |field|
-        address[field] = record[field] || record.dig(*field.split('.'))
+      @geoip_lookup_accessors.each do |field, accessor|
+        address[field] = accessor.call(record)
       end
       address
     end
@@ -167,7 +171,7 @@ module Fluent::Plugin
     def create_placeholder(geodata)
       placeholder = {}
       @placeholder_keys.each do |placeholder_key|
-        position = placeholder_key.match(REGEXP_PLACEHOLDER_SINGLE)
+        position = placeholder_key.match(REGEXP_PLACEHOLDER_SINGLE) || placeholder_key.match(REGEXP_PLACEHOLDER_BRACKET_SINGLE)
         next if position.nil? or geodata[position[:record_key]].nil?
         keys = [position[:record_key]] + position[:geoip_key].split('.').map(&:to_sym)
         value = geodata.dig(*keys)

--- a/lib/fluent/plugin/filter_geoip.rb
+++ b/lib/fluent/plugin/filter_geoip.rb
@@ -52,6 +52,11 @@ module Fluent::Plugin
         @geoip_lookup_keys = @geoip_lookup_key.split(/\s*,\s*/)
       end
 
+      @geoip_lookup_keys.each do |key|
+        if key.include?(".") && !key.start_with?("$")
+          $log.warn("#{key} is not treated as nested attributes")
+        end
+      end
       @geoip_lookup_accessors = @geoip_lookup_keys.map {|key| [key, record_accessor_create(key)] }.to_h
 
       if conf.keys.any? {|k| k =~ /^enable_key_/ }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'test/unit'
+require 'test/unit/rr'
 
 $LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
 $LOAD_PATH.unshift(__dir__)

--- a/test/plugin/test_filter_geoip.rb
+++ b/test/plugin/test_filter_geoip.rb
@@ -195,21 +195,21 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive
       config = %[
         backend_library   geoip2_c
-        geoip_lookup_keys from.ip
+        geoip_lookup_keys $.from.ip
         <record>
-          from_city       ${city.names.en['from.ip']}
-          from_country    ${country.names.en['from.ip']}
-          latitude        ${location.latitude['from.ip']}
-          longitude       ${location.longitude['from.ip']}
-          float_concat    ${location.latitude['from.ip']},${location.longitude['from.ip']}
-          float_array     [${location.longitude['from.ip']}, ${location.latitude['from.ip']}]
-          float_nest      { "lat" : ${location.latitude['from.ip']}, "lon" : ${location.longitude['from.ip']}}
-          string_concat   ${city.names.en['from.ip']},${country.names.en['from.ip']}
-          string_array    [${city.names.en['from.ip']}, ${country.names.en['from.ip']}]
-          string_nest     { "city" : ${city.names.en['from.ip']}, "country_name" : ${country.names.en['from.ip']}}
+          from_city       ${city.names.en['$.from.ip']}
+          from_country    ${country.names.en['$.from.ip']}
+          latitude        ${location.latitude['$.from.ip']}
+          longitude       ${location.longitude['$.from.ip']}
+          float_concat    ${location.latitude['$.from.ip']},${location.longitude['$.from.ip']}
+          float_array     [${location.longitude['$.from.ip']}, ${location.latitude['$.from.ip']}]
+          float_nest      { "lat" : ${location.latitude['$.from.ip']}, "lon" : ${location.longitude['$.from.ip']}}
+          string_concat   ${city.names.en['$.from.ip']},${country.names.en['$.from.ip']}
+          string_array    [${city.names.en['$.from.ip']}, ${country.names.en['$.from.ip']}]
+          string_nest     { "city" : ${city.names.en['$.from.ip']}, "country_name" : ${country.names.en['$.from.ip']}}
           unknown_city    ${city.names.en['unknown_key']}
           undefined       ${city.names.en['undefined']}
-          broken_array1   [${location.longitude['from.ip']}, ${location.latitude['undefined']}]
+          broken_array1   [${location.longitude['$.from.ip']}, ${location.latitude['undefined']}]
           broken_array2   [${location.longitude['undefined']}, ${location.latitude['undefined']}]
         </record>
       ]
@@ -262,13 +262,13 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive_multiple_record
       config = %[
         backend_library   geoip2_c
-        geoip_lookup_keys from.ip, to.ip
+        geoip_lookup_keys $.from.ip, $.to.ip
         <record>
-          from_city       ${city.names.en['from.ip']}
-          to_city         ${city.names.en['to.ip']}
-          from_country    ${country.names.en['from.ip']}
-          to_country      ${country.names.en['to.ip']}
-          string_array    [${country.names.en['from.ip']}, ${country.names.en['to.ip']}]
+          from_city       ${city.names.en['$.from.ip']}
+          to_city         ${city.names.en['$.to.ip']}
+          from_country    ${country.names.en['$.from.ip']}
+          to_country      ${country.names.en['$.to.ip']}
+          string_array    [${country.names.en['$.from.ip']}, ${country.names.en['$.to.ip']}]
         </record>
       ]
       messages = [
@@ -415,6 +415,26 @@ class GeoipFilterTest < Test::Unit::TestCase
       end
       assert_equal(expected, filtered)
     end
+
+    def test_filter_nested_attr_bracket_style
+      config = %[
+        backend_library geoip2_c
+        geoip_lookup_keys  $["host"]["ip"]
+        <record>
+          geoip_city ${city.names.en['$["host"]["ip"]']}
+        </record>
+      ]
+      messages = [
+        {'host' => {'ip' => '66.102.3.80'}, 'message' => 'valid ip'},
+        {'message' => 'missing field'}
+      ]
+      expected = [
+        {'host' => {'ip' => '66.102.3.80'}, 'message' => 'valid ip', 'geoip_city' => 'Mountain View'},
+        {'message' => 'missing field', 'geoip_city' => nil}
+      ]
+      filtered = filter(config, messages)
+      assert_equal(expected, filtered)
+    end
   end
 
   sub_test_case "geoip2_compat" do
@@ -490,21 +510,21 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive
       config = %[
         backend_library   geoip2_compat
-        geoip_lookup_keys from.ip
+        geoip_lookup_keys $.from.ip
         <record>
-          from_city       ${city['from.ip']}
-          from_country    ${country_name['from.ip']}
-          latitude        ${latitude['from.ip']}
-          longitude       ${longitude['from.ip']}
-          float_concat    ${latitude['from.ip']},${longitude['from.ip']}
-          float_array     [${longitude['from.ip']}, ${latitude['from.ip']}]
-          float_nest      { "lat" : ${latitude['from.ip']}, "lon" : ${longitude['from.ip']}}
-          string_concat   ${city['from.ip']},${country_name['from.ip']}
-          string_array    [${city['from.ip']}, ${country_name['from.ip']}]
-          string_nest     { "city" : ${city['from.ip']}, "country_name" : ${country_name['from.ip']}}
+          from_city       ${city['$.from.ip']}
+          from_country    ${country_name['$.from.ip']}
+          latitude        ${latitude['$.from.ip']}
+          longitude       ${longitude['$.from.ip']}
+          float_concat    ${latitude['$.from.ip']},${longitude['$.from.ip']}
+          float_array     [${longitude['$.from.ip']}, ${latitude['$.from.ip']}]
+          float_nest      { "lat" : ${latitude['$.from.ip']}, "lon" : ${longitude['$.from.ip']}}
+          string_concat   ${city['$.from.ip']},${country_name['$.from.ip']}
+          string_array    [${city['$.from.ip']}, ${country_name['$.from.ip']}]
+          string_nest     { "city" : ${city['$.from.ip']}, "country_name" : ${country_name['$.from.ip']}}
           unknown_city    ${city['unknown_key']}
           undefined       ${city['undefined']}
-          broken_array1   [${longitude['from.ip']}, ${latitude['undefined']}]
+          broken_array1   [${longitude['$.from.ip']}, ${latitude['undefined']}]
           broken_array2   [${longitude['undefined']}, ${latitude['undefined']}]
         </record>
       ]
@@ -557,13 +577,13 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive_multiple_record
       config = %[
         backend_library   geoip2_compat
-        geoip_lookup_keys from.ip, to.ip
+        geoip_lookup_keys $.from.ip, $.to.ip
         <record>
-          from_city       ${city['from.ip']}
-          to_city         ${city['to.ip']}
-          from_country    ${country_name['from.ip']}
-          to_country      ${country_name['to.ip']}
-          string_array    [${country_name['from.ip']}, ${country_name['to.ip']}]
+          from_city       ${city['$.from.ip']}
+          to_city         ${city['$.to.ip']}
+          from_country    ${country_name['$.from.ip']}
+          to_country      ${country_name['$.to.ip']}
+          string_array    [${country_name['$.from.ip']}, ${country_name['$.to.ip']}]
         </record>
       ]
       messages = [
@@ -756,9 +776,9 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_nested_attr
       config = %[
         backend_library geoip
-        geoip_lookup_keys  host.ip
+        geoip_lookup_keys  $.host.ip
         <record>
-          geoip_city ${city['host.ip']}
+          geoip_city ${city['$.host.ip']}
         </record>
       ]
       messages = [
@@ -825,10 +845,10 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_multiple_key
       config = %[
         backend_library geoip
-        geoip_lookup_keys  from.ip, to.ip
+        geoip_lookup_keys  $.from.ip, $.to.ip
         <record>
-          from_city ${city['from.ip']}
-          to_city   ${city['to.ip']}
+          from_city ${city['$.from.ip']}
+          to_city   ${city['$.to.ip']}
         </record>
       ]
       messages = [
@@ -847,12 +867,12 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_multiple_key_multiple_record
       config = %[
         backend_library geoip
-        geoip_lookup_keys  from.ip, to.ip
+        geoip_lookup_keys  $.from.ip, $.to.ip
         <record>
-          from_city    ${city['from.ip']}
-          from_country ${country_name['from.ip']}
-          to_city      ${city['to.ip']}
-          to_country   ${country_name['to.ip']}
+          from_city    ${city['$.from.ip']}
+          from_country ${country_name['$.from.ip']}
+          to_city      ${city['$.to.ip']}
+          to_country   ${country_name['$.to.ip']}
         </record>
       ]
       messages = [
@@ -891,21 +911,21 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive
       config = %[
         backend_library geoip
-        geoip_lookup_keys from.ip
+        geoip_lookup_keys $.from.ip
         <record>
-          from_city       ${city['from.ip']}
-          from_country    ${country_name['from.ip']}
-          latitude        ${latitude['from.ip']}
-          longitude       ${longitude['from.ip']}
-          float_concat    ${latitude['from.ip']},${longitude['from.ip']}
-          float_array     [${longitude['from.ip']}, ${latitude['from.ip']}]
-          float_nest      { "lat" : ${latitude['from.ip']}, "lon" : ${longitude['from.ip']}}
-          string_concat   ${city['from.ip']},${country_name['from.ip']}
-          string_array    [${city['from.ip']}, ${country_name['from.ip']}]
-          string_nest     { "city" : ${city['from.ip']}, "country_name" : ${country_name['from.ip']}}
+          from_city       ${city['$.from.ip']}
+          from_country    ${country_name['$.from.ip']}
+          latitude        ${latitude['$.from.ip']}
+          longitude       ${longitude['$.from.ip']}
+          float_concat    ${latitude['$.from.ip']},${longitude['$.from.ip']}
+          float_array     [${longitude['$.from.ip']}, ${latitude['$.from.ip']}]
+          float_nest      { "lat" : ${latitude['$.from.ip']}, "lon" : ${longitude['$.from.ip']}}
+          string_concat   ${city['$.from.ip']},${country_name['$.from.ip']}
+          string_array    [${city['$.from.ip']}, ${country_name['$.from.ip']}]
+          string_nest     { "city" : ${city['$.from.ip']}, "country_name" : ${country_name['$.from.ip']}}
           unknown_city    ${city['unknown_key']}
           undefined       ${city['undefined']}
-          broken_array1   [${longitude['from.ip']}, ${latitude['undefined']}]
+          broken_array1   [${longitude['$.from.ip']}, ${latitude['undefined']}]
           broken_array2   [${longitude['undefined']}, ${latitude['undefined']}]
         </record>
       ]
@@ -958,13 +978,13 @@ class GeoipFilterTest < Test::Unit::TestCase
     def test_filter_record_directive_multiple_record
       config = %[
         backend_library geoip
-        geoip_lookup_keys from.ip, to.ip
+        geoip_lookup_keys $.from.ip, $.to.ip
         <record>
-          from_city       ${city['from.ip']}
-          to_city         ${city['to.ip']}
-          from_country    ${country_name['from.ip']}
-          to_country      ${country_name['to.ip']}
-          string_array    [${country_name['from.ip']}, ${country_name['to.ip']}]
+          from_city       ${city['$.from.ip']}
+          to_city         ${city['$.to.ip']}
+          from_country    ${country_name['$.from.ip']}
+          to_country      ${country_name['$.to.ip']}
+          string_array    [${country_name['$.from.ip']}, ${country_name['$.to.ip']}]
         </record>
       ]
       messages = [

--- a/test/plugin/test_filter_geoip.rb
+++ b/test/plugin/test_filter_geoip.rb
@@ -85,6 +85,36 @@ class GeoipFilterTest < Test::Unit::TestCase
       }
     end
 
+    test "dotted key is not treated as nested attributes" do
+      mock($log).warn("host.ip is not treated as nested attributes")
+      create_driver %[
+        geoip_lookup_keys host.ip
+        <record>
+          city ${city.names.en['host.ip']}
+        </record>
+      ]
+    end
+
+    test "nested attributes bracket style" do
+      mock($log).warn(anything).times(0)
+      create_driver %[
+        geoip_lookup_keys  $["host"]["ip"]
+        <record>
+          geoip_city ${city.names.en['$["host"]["ip"]']}
+        </record>
+      ]
+    end
+
+    test "nested attributes dot style" do
+      mock($log).warn(anything).times(0)
+      create_driver %[
+        geoip_lookup_keys  $.host.ip
+        <record>
+          geoip_city ${city['$.host.ip']}
+        </record>
+      ]
+    end
+
     data(geoip: "geoip",
          geoip2_compat: "geoip2_compat")
     test "unsupported key" do |backend|

--- a/test/plugin/test_filter_geoip.rb
+++ b/test/plugin/test_filter_geoip.rb
@@ -416,12 +416,32 @@ class GeoipFilterTest < Test::Unit::TestCase
       assert_equal(expected, filtered)
     end
 
-    def test_filter_nested_attr_bracket_style
+    def test_filter_nested_attr_bracket_style_double_quote
       config = %[
         backend_library geoip2_c
         geoip_lookup_keys  $["host"]["ip"]
         <record>
           geoip_city ${city.names.en['$["host"]["ip"]']}
+        </record>
+      ]
+      messages = [
+        {'host' => {'ip' => '66.102.3.80'}, 'message' => 'valid ip'},
+        {'message' => 'missing field'}
+      ]
+      expected = [
+        {'host' => {'ip' => '66.102.3.80'}, 'message' => 'valid ip', 'geoip_city' => 'Mountain View'},
+        {'message' => 'missing field', 'geoip_city' => nil}
+      ]
+      filtered = filter(config, messages)
+      assert_equal(expected, filtered)
+    end
+
+    def test_filter_nested_attr_bracket_style_single_quote
+      config = %[
+        backend_library geoip2_c
+        geoip_lookup_keys  $['host']['ip']
+        <record>
+          geoip_city ${city.names.en["$['host']['ip']"]}
         </record>
       ]
       messages = [


### PR DESCRIPTION
Incompatibility notice:

    geoip_lookup_keys host.ip

like dotted style without leading `$` key is not
interpreted as nested attributes.

Use following styles instead:

    geoip_lookup_keys $.host.ip

or

    geoip_lookup_keys $["host"]["ip"]

For more details, see https://docs.fluentd.org/v1.0/articles/api-plugin-helper-record_accessor